### PR TITLE
Fixing `--host` flag when configuring

### DIFF
--- a/base/python/build.sh
+++ b/base/python/build.sh
@@ -15,7 +15,7 @@ build() {
 	./configure \
 		--prefix=/usr \
 		--build=$HOST_TRIPLE \
-		--host=$TRIPLE  \
+		--host=$HOST_TRIPLE  \
 		--with-system-ffi=true \
 		--with-ssl-default-suites=openssl \
 		--without-ensure-pip \


### PR DESCRIPTION
Trying to compile python with iglupkg using the current build.sh will fail and say `--host=$HOST_TRIPLE` is needed instead of `--host=$TRIPLE`