### PR TITLE
Fixing Potential regression in kernel build pkg

### DIFF
--- a/linux/linux/build.sh
+++ b/linux/linux/build.sh
@@ -114,6 +114,8 @@ package() {
 	fi
 
 	bad --gmake gmake CC=cc HOSTCC=cc YACC=yacc LLVM=1 LLVM_IAS=1 ARCH=$_arch headers
+	find usr/include -type f ! -name '*.h' -delete
+	
 	if [ -z "$FOR_CROSS" ]; then
 		install -d $pkgdir/usr/
 		cp -r usr/include $pkgdir/usr/
@@ -121,7 +123,6 @@ package() {
 		install -d $pkgdir/$FOR_CROSS_DIR/
 		cp -r usr/include $pkgdir/$FOR_CROSS_DIR/
 	fi
-	find $pkgdir/usr/include -type f ! -name '*.h' -delete
 }
 
 backup() {

--- a/linux/linux/build.sh
+++ b/linux/linux/build.sh
@@ -114,14 +114,15 @@ package() {
 	fi
 
 	bad --gmake gmake CC=cc HOSTCC=cc YACC=yacc LLVM=1 LLVM_IAS=1 ARCH=$_arch headers
-	find usr/include -type f ! -name '*.h' -delete
 	
 	if [ -z "$FOR_CROSS" ]; then
 		install -d $pkgdir/usr/
 		cp -r usr/include $pkgdir/usr/
+		find $pkgdir/usr/include -type f ! -name '*.h' -delete
 	else
 		install -d $pkgdir/$FOR_CROSS_DIR/
 		cp -r usr/include $pkgdir/$FOR_CROSS_DIR/
+		find $pkgdir/$FOR_CROSS_DIR/ -type f ! -name '*.h' -delete
 	fi
 }
 


### PR DESCRIPTION
[This](https://github.com/iglunix/iglunix/commit/daf545b01f0af5918c5575018eac4d6ac7175976) commit change the kernel build by removing the `find -name '.*' -exec rm {} \;` command and replacing it with a command after the kernel headers have been moved to their output directories. 

But the replacement command doesn't account for if `$FOR_CROSS` build is being performed as in this case the include path is no longer guaranteed to be equal to `$pkdir/usr/include`. In my case see attachment below the actual path for `$FOR_CROSS` build is just `$pkgdir/include` as iglunix autobuild doesn't set any `$FOR_CROSS_DIR` variable.